### PR TITLE
fix(template): remove event forwarding for focus, blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All props are optional.
 | aria-labelledby | `string`                                        |
 | tabindex        | `string`                                        |
 | title           | `string`                                        |
+| focusable       | `boolean` (default: `false`)                    |
 | class           | `string`                                        |
 | style           | `string` (default: `"will-change: transform;"`) |
 
@@ -97,8 +98,6 @@ Event directives are forwarded directly to the SVG element.
   on:mouseleave="{() => {}}"
   on:keyup="{() => {}}"
   on:keydown="{() => {}}"
-  on:focus="{() => {}}"
-  on:blur="{() => {}}"
 />
 ```
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -48,8 +48,6 @@ function template({
   on:mouseleave
   on:keyup
   on:keydown
-  on:focus
-  on:blur
   ${formatAttributes(attrs)}
   class={className}
   {preserveAspectRatio}

--- a/src/template.ts
+++ b/src/template.ts
@@ -35,7 +35,7 @@ function template({
     'aria-labelledby': ariaLabelledBy,
     'aria-hidden': labelled ? undefined : true,
     role: labelled ? 'img' : undefined,
-    focusable: tabindex ? true : focusable,
+    focusable: tabindex === '0' ? true : focusable,
     tabindex
   };
 </script>

--- a/src/tests/__snapshots__/template.spec.ts.snap
+++ b/src/tests/__snapshots__/template.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`icon matches the snapshot 1`] = `
     'aria-labelledby': ariaLabelledBy,
     'aria-hidden': labelled ? undefined : true,
     role: labelled ? 'img' : undefined,
-    focusable: tabindex ? true : focusable,
+    focusable: tabindex === '0' ? true : focusable,
     tabindex
   };
 </script>

--- a/src/tests/__snapshots__/template.spec.ts.snap
+++ b/src/tests/__snapshots__/template.spec.ts.snap
@@ -32,8 +32,6 @@ exports[`icon matches the snapshot 1`] = `
   on:mouseleave
   on:keyup
   on:keydown
-  on:focus
-  on:blur
   xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 32 32\\" width=\\"32\\" height=\\"32\\"
   class={className}
   {preserveAspectRatio}


### PR DESCRIPTION
Fixes #20 

**Changes**

- Remove `on:focus`, `on:blur` forwarded events
- Use strict checking for `tabindex` to override `focusable` prop